### PR TITLE
Minor Typo Fix towards PAS-404

### DIFF
--- a/src/guide/api.md
+++ b/src/guide/api.md
@@ -263,7 +263,7 @@ A few rules to take into consideration when allowing users to create aliases:
 
 ### Response
 
-Alias are never returned in any API responses, and can be hashed to preserve user privacy (see above). If successful, the `/alias` endpoint will return an HTTP 204 (NoContent) [status code](#status-codes).
+Alias are never returned in any API responses, and can be hashed to preserve user privacy (see above). If successful, the `/alias` endpoint will return an HTTP 204 (No Content) [status code](#status-codes).
 
 ## `/credentials/list`
 


### PR DESCRIPTION
### Ticket
- Closes [PAS-404](https://bitwarden.atlassian.net/browse/PAS-404)

### Description
Very small change to add a space to `NoContent` to be consistent with the rest of our documentation.

### Screenshots 
<img width="935" alt="Screenshot 2024-04-09 at 17 42 57" src="https://github.com/bitwarden/passwordless-docs/assets/67128872/52becab3-42cc-458c-a42a-4174ee338ffc">

### Checklist

I did the following to ensure that my changes were tested thoroughly:

- Validated in the (preview site)[https://32e7f8f6.passwordless-docs.pages.dev/guide/api.html#response-3] that the change looks okay (See screenshot above)

I did the following to ensure that my changes do not introduce security vulnerabilities:

- N/A


[PAS-404]: https://bitwarden.atlassian.net/browse/PAS-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ