### PR TITLE
Missing `coreutils` dependency in documentation

### DIFF
--- a/src/guide/frontend/android.md
+++ b/src/guide/frontend/android.md
@@ -104,6 +104,21 @@ To obtain the Facet ID continue the steps below, the Facet ID typically looks li
 
 @tab Bash
 
+1. Install dependencies:
+   - MacOS:
+     1. Install Homebrew
+     2. Execute the following command:
+       ```sh
+       brew install coreutils
+       ``` 
+   - Ubuntu:
+       ```shell
+       sudo apt-get update
+       sudo apt-get install coreutils
+       ```
+
+2. Extract the SHA-256 hash:
+
 ```bash
 # Linux, Mac OS, Git Bash, ...
 keytool -list -v -keystore ~/.android/debug.keystore | grep "SHA256: " | cut -d " " -f 3 | xxd -r -p | basenc --base64url | sed 's/=//g'

--- a/src/guide/frontend/android.md
+++ b/src/guide/frontend/android.md
@@ -102,22 +102,27 @@ To obtain the Facet ID continue the steps below, the Facet ID typically looks li
 
 ::: tabs
 
-@tab Bash
+@tab Bash MacOS
 
-1. Install dependencies:
+1. Install Homebrew
+2. Execute the following command:
+   ```sh
+   brew install coreutils
+   ```
+3. Extract the SHA-256 hash:
 
-   - MacOS:
-     1. Install Homebrew
-     2. Execute the following command:
-     ```sh
-     brew install coreutils
-     ```
-   - Ubuntu:
-     ```shell
-     sudo apt-get update
-     sudo apt-get install coreutils
-     ```
+```bash
+# Linux, Mac OS, Git Bash, ...
+keytool -list -v -keystore ~/.android/debug.keystore | grep "SHA256: " | cut -d " " -f 3 | xxd -r -p | basenc --base64url | sed 's/=//g'
+```
 
+@tab Bash Ubuntu
+
+1. Execute the following commands in your terminal to install any missing dependencies.
+   ```shell
+   sudo apt-get update
+   sudo apt-get install coreutils
+   ```
 2. Extract the SHA-256 hash:
 
 ```bash

--- a/src/guide/frontend/android.md
+++ b/src/guide/frontend/android.md
@@ -105,17 +105,18 @@ To obtain the Facet ID continue the steps below, the Facet ID typically looks li
 @tab Bash
 
 1. Install dependencies:
+
    - MacOS:
      1. Install Homebrew
      2. Execute the following command:
-       ```sh
-       brew install coreutils
-       ``` 
+     ```sh
+     brew install coreutils
+     ```
    - Ubuntu:
-       ```shell
-       sudo apt-get update
-       sudo apt-get install coreutils
-       ```
+     ```shell
+     sudo apt-get update
+     sudo apt-get install coreutils
+     ```
 
 2. Extract the SHA-256 hash:
 


### PR DESCRIPTION
### Description

Doing a clean system restore, I discovered that `baseenc` couldn't be resolved when following the instructions to obtain the Facet ID. The resolution for the missing dependency is to install the `coreutils` package on MacOS.

It is not clear whether the dependency was included by default on Ubuntu, but for convenience, it was added to the documentation just in case someone must have uninstalled the required dependency.

### Shape

n/a

### Screenshots

<img width="773" alt="image" src="https://github.com/bitwarden/passwordless-docs/assets/1045327/10322e56-f697-4f36-a00e-d3f61dd138d4">

<img width="773" alt="image" src="https://github.com/bitwarden/passwordless-docs/assets/1045327/68dca58e-e776-4e90-ba9f-1a622f969a6b">

### Checklist

I did the following to ensure that my changes were tested thoroughly:

- See screenshots

I did the following to ensure that my changes do not introduce security vulnerabilities:

- \_\_
