### PR TITLE
Add INTERNET permission through the library

### DIFF
--- a/src/guide/frontend/android.md
+++ b/src/guide/frontend/android.md
@@ -22,27 +22,29 @@ The Passwordless.dev Android client SDK gives users the ability to leverage thei
 <dependency>
   <groupId>com.bitwarden</groupId>
   <artifactId>passwordless-android</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 
 @tab Gradle Kotlin DSL
 
 ```kotlin
-implementation("com.bitwarden:passwordless-android:1.0.1")
+implementation("com.bitwarden:passwordless-android:1.0.4")
 ```
 
 @tab Gradle Groovy DSL
 
 ```groovy
-implementation 'com.bitwarden:passwordless-android:1.0.1'
+implementation 'com.bitwarden:passwordless-android:1.0.4'
 ```
 
 :::
 
 ## Permissions
 
-In your `AndroidManifest.xml`, add the following permissions:
+When the library has been added to your app, the following permission will be added to your `AndroidManifest.xml` automatically when the app is being built.
+
+It is not necessary for you to add the following permission.
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
### Description

The INTERNET permission should be added through the library when it is referenced in the app project.

This could potentially make the integration easier if more permissions are to be required in the future.

### Shape

We can now remove the INTERNET permission theoretically in our app manifest, although our app also specifically requires the INTERNET permission to communicate with the demo backend that we have hosted. This demo backend would be the customer's backend where the integration would happen.

### Screenshots

<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist

I did the following to ensure that my changes were tested thoroughly:

- \_\_

I did the following to ensure that my changes do not introduce security vulnerabilities:

- \_\_
