### PR TITLE
PAS-531 | Drop `Facet ID` instructions for Android SDK. Integration simplified.

### DIFF
--- a/src/guide/frontend/android.md
+++ b/src/guide/frontend/android.md
@@ -22,20 +22,20 @@ The Passwordless.dev Android client SDK gives users the ability to leverage thei
 <dependency>
   <groupId>com.bitwarden</groupId>
   <artifactId>passwordless-android</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
 @tab Gradle Kotlin DSL
 
 ```kotlin
-implementation("com.bitwarden:passwordless-android:1.0.4")
+implementation("com.bitwarden:passwordless-android:1.1.0")
 ```
 
 @tab Gradle Groovy DSL
 
 ```groovy
-implementation 'com.bitwarden:passwordless-android:1.0.4'
+implementation 'com.bitwarden:passwordless-android:1.1.0'
 ```
 
 :::
@@ -61,9 +61,6 @@ data class PasswordlessOptions(
 
    // Identifier for your server, for example 'example.com' if your backend is hosted at https://example.com.
    val rpId: String,
-
-   // This is where your Facet ID goes
-   val origin: String,
 
    // Where your backend is hosted
    val backendUrl:String,
@@ -91,78 +88,6 @@ In your application's `res/xml/assetlinks.xml`, you will then need to add the fo
     <string name="assetlinks">https://yourexample.com/.well-known/assetlinks.json</string>
 </resources>
 ```
-
-### Facet ID
-
-The `Facet ID` will be used later in this guide as the `origin`.
-
-To obtain the Facet ID continue the steps below, the Facet ID typically looks like:
-
-`android:apk-key-hash:POIplOLeHuvl-XAQckH0DwY4Yb1ydnnKcmhn-jibZbk`
-
-1. Execute the following command in your terminal:
-
-::: tabs
-
-@tab Bash MacOS
-
-1. Install Homebrew
-2. Execute the following command:
-   ```sh
-   brew install coreutils
-   ```
-3. Extract the SHA-256 hash:
-
-```bash
-# Linux, Mac OS, Git Bash, ...
-keytool -list -v -keystore ~/.android/debug.keystore | grep "SHA256: " | cut -d " " -f 3 | xxd -r -p | basenc --base64url | sed 's/=//g'
-```
-
-@tab Bash Ubuntu
-
-1. Execute the following commands in your terminal to install any missing dependencies.
-   ```shell
-   sudo apt-get update
-   sudo apt-get install coreutils
-   ```
-2. Extract the SHA-256 hash:
-
-```bash
-# Linux, Mac OS, Git Bash, ...
-keytool -list -v -keystore ~/.android/debug.keystore | grep "SHA256: " | cut -d " " -f 3 | xxd -r -p | basenc --base64url | sed 's/=//g'
-```
-
-@tab Powershell
-
-```powershell
-# Run keytool command and extract SHA256 hash
-$keytoolOutput = keytool -list -v -keystore $HOME\.android\debug.keystore
-$sha256Hash = ($keytoolOutput | Select-String "SHA256: ").ToString().Split(" ")[2]
-
-# Remove any non-hex characters from the hash
-$hexHash = $sha256Hash -replace "[^0-9A-Fa-f]"
-
-# Convert the hexadecimal string to a byte array
-$byteArray = [byte[]]@()
-for ($i = 0; $i -lt $hexHash.Length; $i += 2) {
-  $byteArray += [byte]([Convert]::ToUInt32($hexHash.Substring($i, 2), 16))
-}
-
-# Convert the byte array to a base64 string
-$base64String = [Convert]::ToBase64String($byteArray)
-
-# Convert the base64 string to a base64url string
-$base64urlString = $base64String -replace '\+', '-' -replace '/', '_' -replace '=+$', ''
-
-Write-Output $base64urlString
-```
-
-:::
-
-2. The default password for the debug keystore is `android`. For your production keystore, enter your chosen password.
-
-3. Now append the result to `android:apk-key-hash:` to get the Facet ID:
-   `android:apk-key-hash:POIplOLeHuvl-XAQckH0DwY4Yb1ydnnKcmhn-jibZbk`
 
 ## Configuration (Your back-end)
 


### PR DESCRIPTION
### Ticket

<!-- For Jira Tasks: (remove if external contributor)  -->

- Closes [PAS-531](https://bitwarden.atlassian.net/browse/PAS-531)

<!-- For GitHub Issues: -->
<!-- - Closes #XXX -->

### Description

Simplifies the instructions for the Android SDK as the calculation of the origin is automated.

Only merge into `main` after, [/bitwarden/passwordless-android/pull/70](https://github.com/bitwarden/passwordless-android/pull/70) is merged and released. 

### Shape

<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots

<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist

I did the following to ensure that my changes were tested thoroughly:

- \_\_

I did the following to ensure that my changes do not introduce security vulnerabilities:

- \_\_


[PAS-531]: https://bitwarden.atlassian.net/browse/PAS-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ