### PR TITLE
[PM-30551] Fix: Lint only *.ts and *.vue files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "dev": "vuepress dev src",
     "build": "vuepress build src",
-    "lint": "prettier . --write && eslint \"**/*.{js,ts,vue}\" --fix",
-    "lint:check": "prettier . --check && eslint \"**/*.{js,ts,vue}\""
+    "lint": "prettier . --write && eslint \"**/*.{ts,vue}\" --fix",
+    "lint:check": "prettier . --check && eslint \"**/*.{ts,vue}\""
   },
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.1.2",


### PR DESCRIPTION
## Description
This PR fixes an issue where the lint script was unintentionally 
checking `.js` files in addition to `.ts` and `.vue` files.

## Changes
- Modified `lint` script in package.json to exclude `*.js` files
- Modified `lint:check` script in package.json to exclude `*.js` files

## Testing
- Ran `yarn run lint` successfully - all files pass linting
- Ran `yarn run dev` - site builds and runs correctly on localhost:8080

Fixes #135 