### PR TITLE
Fix embedded Open API spec failing to render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@passwordlessdev/passwordless-client": "1.1.2",
-        "swagger-ui-dist": "5.12.3"
+        "swagger-ui-dist": "5.32.12"
       },
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.26",
@@ -1879,6 +1879,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -6354,10 +6361,13 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.12.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.12.3.tgz",
-      "integrity": "sha512-UAFxQSzxVkY/yfmipeMLj4LwH6I/ZGcfezwSquPm2U9CqOiHp8L6fD7TcyPDYfCZuHFaPw5y4io+fny37Ov9NQ==",
-      "license": "Apache-2.0"
+      "version": "5.32.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+      "integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     },
     "node_modules/swr": {
       "version": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "engines": {
     "node": ">=20.10.0"
   },
+  "scarfSettings": {
+    "enabled": false
+  },
   "scripts": {
     "dev": "vuepress dev src",
     "build": "vuepress build src",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@passwordlessdev/passwordless-client": "1.1.2",
-    "swagger-ui-dist": "5.12.3"
+    "swagger-ui-dist": "5.32.12"
   },
   "devDependencies": {
     "@vuepress/bundler-vite": "2.0.0-rc.26",

--- a/src/.vuepress/components/SwaggerComponent.vue
+++ b/src/.vuepress/components/SwaggerComponent.vue
@@ -29,6 +29,17 @@ h2.title,
   display: none;
 }
 
+/* The default theme defines an unscoped `.arrow` class that paints a chevron as a
+   1em background-image. Swagger UI marks its own inline SVG chevrons with
+   class="arrow", so both get drawn — a second chevron behind each one, with the SVG
+   stretched to 1em. Undo the theme's rule inside the embed; `auto` lets each SVG
+   fall back to its own width/height attributes. */
+.swagger-ui .arrow {
+  width: auto;
+  height: auto;
+  background-image: none;
+}
+
 .page .theme-default-content {
   max-width: 100%;
 }

--- a/src/guide/api-documentation.md
+++ b/src/guide/api-documentation.md
@@ -1,5 +1,6 @@
 # Open API
 
-This page embeds the Open API Swagger spec.
+This page embeds the Open API Swagger spec. It is also available as a standalone page at
+[api.passwordless.dev/swagger](https://api.passwordless.dev/swagger/index.html).
 
 <swagger-component></swagger-component>


### PR DESCRIPTION
### Description

The embedded Swagger spec on [/guide/api-documentation](https://docs.passwordless.dev/guide/api-documentation.html) stopped rendering, showing Swagger UI's *"Unable to render this definition — The provided definition does not specify a valid version field."*

Nothing on the docs side changed — the API's spec did. It now declares `openapi: "3.0.4"`, and the pinned `swagger-ui-dist@5.12.3` gates rendering on a hardcoded patch allowlist:

```js
function isOAS30(s){const i=s.get("openapi");return"string"==typeof i&&/^3\.0\.([0123])(?:-rc[012])?$/.test(i)}
```

`3.0.4` fails it. (`api.passwordless.dev/swagger/index.html` kept working because it serves its own, much newer Swagger UI — only the embed was pinned to the old one.)

### Shape

**1. `swagger-ui-dist` 5.12.3 → 5.32.12.** The new version replaced the allowlist with `/^3\.0\.(?:[1-9]\d*|0)$/`, so it accepts any 3.0.x patch and won't break again on 3.0.5:

| `openapi` | 5.12.3 | 5.32.12 |
| --- | --- | --- |
| `3.0.1` | accepted | accepted |
| `3.0.3` | accepted | accepted |
| `3.0.4` | **rejected** | accepted |

No component changes were needed for the upgrade — the named `SwaggerUIBundle` export and the `swagger-ui.css` path both still resolve.

**2. `.arrow` CSS reset.** Fixing the above surfaced a second, pre-existing bug: collapsible controls each drew two overlapping chevrons. `@vuepress/theme-default` defines an **unscoped** `.arrow` class that paints a chevron as a 1em `background-image` ([`arrow.scss`](https://github.com/vuepress/core/blob/main/themes/theme-default/src/client/styles/arrow.scss)), and Swagger UI tags its own inline SVG chevrons with `class="arrow"` — so the theme's chevron got painted behind Swagger's, and the SVGs were stretched from their native 10px to 1em. Reset inside the embed only:

```css
.swagger-ui .arrow {
  width: auto;
  height: auto;
  background-image: none;
}
```

`auto` rather than a fixed size because Swagger uses different arrow sizes (10px on opblocks, 20px on the expand-all control), so each SVG falls back to its own attributes. No `!important` needed — `.swagger-ui .arrow` (0,2,0) outranks `.arrow` (0,1,0), and it also emits after the `[data-theme=dark] .arrow` variant it ties with.

This was latent, not caused by the upgrade: 5.12.3 emits the identical `class="arrow"` markup. It was simply invisible while the version gate blocked rendering entirely. I checked all 10 generic unscoped classes the theme defines against every `className` in the Swagger bundle — `arrow` is the only collision.

**3. Opted out of Scarf install analytics.** The upgrade pulls in **`@scarf/scarf@1.4.0`**, which `swagger-ui-dist` now pins as a hard (non-optional) dependency. It has a `postinstall` that reports install telemetry to scarf.sh — its own description: *"Scarf is like Google Analytics for your npm packages… Gain insights into how your packages are installed and used, and by which companies."* Disabled via the root `package.json`:

```json
"scarfSettings": {
  "enabled": false
}
```

The package is still installed — there's no way to avoid that while it's a hard dependency — but its reporting is off, so neither developer machines nor CI phone home. It's the only new package in the lockfile.

**4. Docs copy.** Linked the standalone Swagger page from the intro paragraph.

### Screenshots

Not included — see the testing note below.

### Checklist

I did the following to ensure that my changes were tested thoroughly:

- `npm run build` succeeds and `npm run lint:check` is clean.
- Verified the root cause mechanically: extracted the version-gate regex from both bundles and tested `3.0.1` / `3.0.3` / `3.0.4` against each (table above).
- Confirmed the theme's unscoped `.arrow` rule ships in the built stylesheet, and that the override lands in the build output after it.
- **Not visually verified.** The chevron fix was confirmed by reading the CSS cascade, not by looking at the rendered page — I couldn't get a browser attached. Please eyeball the collapsible headers before approving; this is the main reason it's a draft.

I did the following to ensure that my changes do not introduce security vulnerabilities:

- Reviewed the full lockfile diff: only `swagger-ui-dist` itself changed, plus the one new transitive `@scarf/scarf`, whose telemetry is disabled as described above. No other packages added, removed, or re-resolved.
- Verified the Scarf opt-out actually takes effect rather than trusting the setting: its `report.js` checks `scarfSettings.enabled === false` and rejects *before* reaching its `https.request` call, and running the postinstall directly now aborts with `Scarf has been disabled via a package.json in the dependency chain.`
- Confirmed the spec is fetched over HTTPS from the existing host with `supportedSubmitMethods: []`, so the embed remains read-only and cannot issue live API calls.
